### PR TITLE
Fix wrong handling of LabelDefs of Nothing type.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jribble/NormalizeForJribble.scala
+++ b/src/compiler/scala/tools/nsc/backend/jribble/NormalizeForJribble.scala
@@ -256,7 +256,7 @@ with JribbleNormalization
         val paramLocals = params.map(x => allocLocal(x.tpe, x.pos))
         newStats ++= paramLocals map (ValDef)
         recordLabelDefDuring(tree.symbol, paramLocals) {
-          if (isUnit(rhs.tpe)) {
+          if (isUnitOrNothing(rhs)) {
             treeCopy.LabelDef(tree, name, params, transformStatement(explicitBlock(rhs)))
           } else {
             val resultLocal = allocLocal(rhs.tpe, tree.pos)

--- a/test/files/jribble/patternmatching.check/PatternMatching.jribble
+++ b/test/files/jribble/patternmatching.check/PatternMatching.jribble
@@ -49,6 +49,28 @@ public class LPatternMatching; extends Ljava/lang/Object; implements Lscala/Scal
     I; y = x$1.(Lscala/Tuple2;::_2$mcI$sp()I;)();
   }
   
+  public I; throwInPatternBranch(I; x) {
+    I; temp11 = x;
+    I; x = temp11;
+    I; $4$;
+    if (this.(LPatternMatching;::gd1$1(I;)Z;)(x))
+      {
+        I; $5$;
+        body$percent03: while(true) {
+          throw (new (Ljava/lang/RuntimeException;::this(Ljava/lang/String;)V;)("don\'t like zeros"));
+        }
+      }
+    else
+      {
+        $4$ = temp11;
+      }
+    return $4$;
+  }
+  
+  private final Z; gd1$1(I; x$1) {
+    return (x$1 == 0);
+  }
+  
   public this() {
     (Ljava/lang/Object;::super()V;)();
   }

--- a/test/files/jribble/patternmatching.scala
+++ b/test/files/jribble/patternmatching.scala
@@ -19,5 +19,13 @@ class PatternMatching {
   def unpackTuple(t: (Int, Int)) = {
     val (x, y) = t
   }
+  
+  def throwInPatternBranch(x: Int): Int = x match {
+      //having a guard expression triggers pattern matching to emit a tree
+      //of slightly different shape that would result with assignment to
+      //a variable with throw on rhs which is invalid jribble construct
+      case x if x == 0 => throw new RuntimeException("don't like zeros")
+      case x => x
+    }
 
 }


### PR DESCRIPTION
LabelDefs of Nothing type would have a synthetic
ValDef introduced to carry it's result. This is
wrong because we always discard assignments to
with rhs of Nothing type.

It's worth noting that the whole logic is still
broken but not in this particular case. The problem
is with LabelDefs changing it type while being
rewritten. It's confusing the rest of the logic
in NormalizeForJribble. I think it's a good
reason to split this logic into two pieces and
perform two tree traversals instead of one.

Signed-off-by: Grzegorz Kossakowski grzegorz.kossakowski@gmail.com
