### PR TITLE
Fix wrong object initialization order.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jribble/GenJribble.scala
+++ b/src/compiler/scala/tools/nsc/backend/jribble/GenJribble.scala
@@ -200,6 +200,13 @@ with JribbleNormalization
      * them should be printed as continue's.
      */
     val labelSyms = mut.Set.empty[Symbol]
+    
+    //TODO(grek): Idea of this field comes from GenJVM backend code but it's fairly ugly hack. We should seriously
+    //consider extracting such things like module initialization, module static forwarders, etc. into separate
+    //compiler phase that both jribble and genjvm can share
+    private var isModuleInitialized = false
+    
+    private var currentMethod: Symbol = NoSymbol
 
     override def printRaw(tree: Tree): Unit = printRaw(tree, false)
     
@@ -305,6 +312,8 @@ with JribbleNormalization
         print(";")
 
       case tree@DefDef(mods, name, tparams, vparamss, tp, rhs) =>
+        val oldCurrentMethod = currentMethod
+        currentMethod = tree.symbol
         val resultType = tree.symbol.tpe.resultType
         
         // TODO(spoon): decide about these two prints; put them in or delete the comments
@@ -326,6 +335,7 @@ with JribbleNormalization
           print(" ")
           printInBraces(rhs, true)
         }
+        currentMethod = oldCurrentMethod
 
       case Block(stats, expr) =>
         assert (expr equalsStructure Literal(()))
@@ -420,6 +430,12 @@ with JribbleNormalization
       case tree@Apply(Select(_: Super, nme.CONSTRUCTOR), args) if tree.symbol.isConstructor =>
         print(jribbleSuperConstructorSignature(tree.symbol))
         printParams(args)
+        // we initialize the MODULE$ field immediately after the super ctor, see GenJVM
+        if (isStaticModule(clazz) && !isModuleInitialized && currentMethod.name == nme.CONSTRUCTOR) {
+          isModuleInitialized = true
+          print(";"); println;
+          print(jribbleName(clazz)); print("."); print(nme.MODULE_INSTANCE_FIELD); print(" = this"); 
+        }
 
       //trigerred by call to auxiliary constructor
       case tree@Apply(Select(receiver, nme.CONSTRUCTOR), args) if tree.symbol.isConstructor =>

--- a/test/files/jribble/caseclass.check/CaseClass$.jribble
+++ b/test/files/jribble/caseclass.check/CaseClass$.jribble
@@ -32,5 +32,6 @@ public final class LCaseClass$; extends Lscala/runtime/AbstractFunction1; implem
   
   public this() {
     (Lscala/runtime/AbstractFunction1;::super()V;)();
+    LCaseClass$;.MODULE$ = this;
   }
 }

--- a/test/files/jribble/companionobject.check/Foo$.jribble
+++ b/test/files/jribble/companionobject.check/Foo$.jribble
@@ -13,6 +13,7 @@ public final class LFoo$; extends Ljava/lang/Object; implements Lscala/ScalaObje
   
   public this() {
     (Ljava/lang/Object;::super()V;)();
+    LFoo$;.MODULE$ = this;
     this.(LFoo$;)x$u0020 = 1;
   }
 }

--- a/test/files/jribble/hello.check/HelloWorld$.jribble
+++ b/test/files/jribble/hello.check/HelloWorld$.jribble
@@ -7,5 +7,6 @@ public final class LHelloWorld$; extends Ljava/lang/Object; implements Lscala/Sc
   
   public this() {
     (Ljava/lang/Object;::super()V;)();
+    LHelloWorld$;.MODULE$ = this;
   }
 }

--- a/test/files/jribble/object.check/TestObject$.jribble
+++ b/test/files/jribble/object.check/TestObject$.jribble
@@ -23,6 +23,7 @@ public final class LTestObject$; extends Ljava/lang/Object; implements Lscala/Sc
   
   public this() {
     (Ljava/lang/Object;::super()V;)();
+    LTestObject$;.MODULE$ = this;
     this.(LTestObject$;)field$u0020 = 0;
     this.(LTestObject$;)mutableField$u0020 = 0;
   }

--- a/test/files/jribble/trait.check/OuterObject$.jribble
+++ b/test/files/jribble/trait.check/OuterObject$.jribble
@@ -3,5 +3,6 @@ public final class LOuterObject$; extends Ljava/lang/Object; implements Lscala/S
   
   public this() {
     (Ljava/lang/Object;::super()V;)();
+    LOuterObject$;.MODULE$ = this;
   }
 }

--- a/test/files/jribble/valdef.check/ValDef$.jribble
+++ b/test/files/jribble/valdef.check/ValDef$.jribble
@@ -9,6 +9,7 @@ public final class LValDef$; extends Ljava/lang/Object; implements Lscala/ScalaO
   
   public this() {
     (Ljava/lang/Object;::super()V;)();
+    LValDef$;.MODULE$ = this;
     this.(LValDef$;)b$u0020 = 1;
   }
 }


### PR DESCRIPTION
The exact problem is described in ticket #18.
In short, we should initialize MODULE$ field generated
for object as soon as superconstructor is called and
not wait until rest of constructor is executed.

Logic that implements this behaviour follows very
closely the one from jvm backend.

For things like that, it would be _far more_ preferable
to share the logic between GenJVM and Jribble backend.
Ultimately, this should result in a separate compiler
phase (executed after cleanup and before icode) that
both jvm and jribble backends would share. However, this
is rather major refactoring and will require some time
to implement so I'm pushing this change for now.

Also, updated test-cases to reflect this change.

Fixes #18.

Signed-off-by: Grzegorz Kossakowski grzegorz.kossakowski@gmail.com
