### PR TITLE
Build scala library for gwt with continuations enabled.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -464,11 +464,12 @@ QUICK BUILD (QUICK)
     </uptodate>
   </target>
 
-  <target name="quick.pre-lib-jribble" depends="quick.lib-jdk2ikvm">
+  <target name="quick.pre-lib-jribble" depends="quick.lib-jdk2ikvm, quick.plugins">
     <uptodate property="quick.lib-jribble.available" targetfile="${build-quick.dir}/library-jribble.complete">
       <srcfiles dir="${build-quick.dir}/jdk2ikvm">
         <include name="library/**"/>
         <include name="factorymanifests/**"/>
+        <include name="continuations/**"/>
       </srcfiles>
     </uptodate>
     <path id="quick.classpath">
@@ -566,6 +567,7 @@ QUICK BUILD (QUICK)
       jvmargs="${scalacfork.jvmargs}">
       <include name="scala/**/*.scala"/>
       <include name="scala/**/*.java"/>
+      <exclude name="scala/util/continuations/**"/>
     </scalacfork>
     <!-- Delete jribble files corresponding to primitive types. Name of classes declared for
          primitive types are broken and would cause parsing error. Those classes are stubs
@@ -583,6 +585,16 @@ QUICK BUILD (QUICK)
         <include name="Unit.jribble"/>
       </fileset>
     </delete>
+    <scalacfork
+      destdir="${build-quick.dir}/jribble/library"
+      compilerpathref="quick.classpath"
+      params="${scalac.args.quick} -Xpluginsdir ${build-quick.dir}/misc/scala-devel/plugins -Xplugin-require:continuations -P:continuations:enable"
+      srcdir="${build-quick.dir}/jdk2ikvm/library"
+      target="jribble"
+      jvmargs="${scalacfork.jvmargs}">
+      <include name="scala/util/continuations/**"/>
+      <compilationpath refid="quick.compilation.path"/>
+    </scalacfork>
     <mkdir dir="${build-quick.dir}/classes/library-gwt"/>
     <scalacfork
       destdir="${build-quick.dir}/classes/library-gwt"
@@ -594,6 +606,23 @@ QUICK BUILD (QUICK)
       <include name="scala/**/*.scala"/>
       <include name="scala/**/*.java"/>
     </scalacfork>
+    <scalacfork
+      destdir="${build-quick.dir}/classes/library-gwt"
+      compilerpathref="quick.classpath"
+      params="${scalac.args.quick} -Xpluginsdir ${build-quick.dir}/misc/scala-devel/plugins -Xplugin-require:continuations -P:continuations:enable"
+      srcdir="${build-quick.dir}/jdk2ikvm/library"
+      jvmargs="${scalacfork.jvmargs}">
+      <include name="scala/util/continuations/**"/>
+      <compilationpath refid="quick.compilation.path"/>
+    </scalacfork>
+    <javac
+      srcdir="${build-quick.dir}/jdk2ikvm/library"
+      destdir="${build-quick.dir}/classes/library-gwt"
+      classpath="${build-quick.dir}/classes/library"
+      includes="**/*.java"
+      target="1.5" source="1.5">
+      <compilerarg line="${javac.args}"/> 
+    </javac>
     <propertyfile file="${build-quick.dir}/jribble/library/library.properties">
       <entry key="version.number" value="${version.number}"/>
       <entry key="copyright.string" value="${copyright.string}"/>
@@ -732,18 +761,39 @@ QUICK BUILD (QUICK)
       <pathelement location="${forkjoin.jar}"/>
       <pathelement location="${ant.jar}"/>
     </path>
+    <mkdir dir="${build-quick.dir}/pre-jdk2ikvm/library"/>
+    <!-- HACK!(grek): If we copy with copy ant target then scala compiler fails with NPE.
+         I believe we rely on some order that is only preserved if all attributes
+         of files being copied are preserved. On my system it's enough to just
+         omit -p flag for cp commmand to make build fail. Obviously, it's a bug
+         in scala compiler but I don't want to spend time fixing it when fairly
+         easy work-around is present. This stuff will be moved out of scalagwt-scala
+         project soon anyway. -->
+    <exec executable="cp">
+      <arg value="-Rp"/>
+      <arg value="${src.dir}/library/"/>
+      <arg value="${build-quick.dir}/pre-jdk2ikvm/library/"/>
+    </exec>
+    <copy todir="${build-quick.dir}/pre-jdk2ikvm/library">
+      <fileset dir="${src.dir}/factorymanifests/library">
+        <include name="**/*.scala"/>
+      </fileset>
+      <fileset dir="${src.dir}/continuations/library">
+        <include name="**/*.scala"/>
+      </fileset>
+    </copy>
     <mkdir dir="${build-quick.dir}/jdk2ikvm/library"/>
     <scalacfork
       destdir="${build-quick.dir}/jdk2ikvm/library"
       compilerpathref="quick.classpath"
-      srcpath="${src.dir}/library"
+      srcpath="${build-quick.dir}/pre-jdk2ikvm/library"
       params="-Ystop-before:superaccessors
 			    -P:jdk2ikvm:output-directory:${build-quick.dir}/jdk2ikvm/library
 			    -P:jdk2ikvm:replacements-directory:${src.dir}/jdk2ikvm/resources/replacements
 			    -d ${build-quick.dir}/jdk2ikvm/library
 			    -Xplugin ${build-quick.dir}/misc/scala-devel/jdk2ikvm.jar
 			    -Yrangepos"
-      srcdir="${src.dir}/library"
+      srcdir="${build-quick.dir}/pre-jdk2ikvm/library"
       jvmargs="${scalacfork.jvmargs}">
       <include name="**/*.scala"/>
       <compilationpath refid="quick.compilation.path"/>
@@ -757,13 +807,8 @@ QUICK BUILD (QUICK)
     <!-- now we copy rest of Java files that have no correspodning replacement defined. Copy ant task doesn't
     overwrite by default so files copied above will be kept intact -->
     <copy todir="${build-quick.dir}/jdk2ikvm/library">
-      <fileset dir="${src.dir}/library">
+      <fileset dir="${build-quick.dir}/pre-jdk2ikvm/library">
         <include name="**/*.java"/>
-      </fileset>
-    </copy>
-    <copy todir="${build-quick.dir}/jdk2ikvm/library">
-      <fileset dir="${src.dir}/factorymanifests/library">
-        <include name="**/*.scala"/>
       </fileset>
     </copy>
     <touch file="${build-quick.dir}/library-jdk2ikvm.complete" verbose="no"/>

--- a/src/jdk2ikvm/resources/replacements/README.txt
+++ b/src/jdk2ikvm/resources/replacements/README.txt
@@ -104,3 +104,11 @@ However, this object is being referenced from other places in xml package.
 This object has to be rewritten because of dependencies on methods in RichChar
 that are removed. Check scala/runtime/RichChar for details.
 
+scala/util/continuations/package.scala
+--------------------------------------
+Change NoSuchMethodException to RuntimeException as GWT doesn't support former.
+See https://github.com/scalagwt/scalagwt-scala/issues/22
+
+scala/util/continuations/ControlContext.scala
+---------------------------------------------
+Work-arounds (rewrites) for pattern matcher shortcomings.

--- a/src/jdk2ikvm/resources/replacements/scala/util/continuations/ControlContext.scala
+++ b/src/jdk2ikvm/resources/replacements/scala/util/continuations/ControlContext.scala
@@ -1,0 +1,173 @@
+// $Id$
+
+package scala.util.continuations
+import annotation.{ Annotation, StaticAnnotation, TypeConstraint }
+
+class cpsParam[-B,+C] extends StaticAnnotation with TypeConstraint
+
+private class cpsSym[B] extends Annotation // implementation detail
+
+private class cpsSynth extends Annotation // implementation detail
+
+private class cpsPlus extends StaticAnnotation with TypeConstraint // implementation detail
+private class cpsMinus extends Annotation // implementation detail
+
+
+
+final class ControlContext[+A,-B,+C](val fun: (A => B, Exception => B) => C, val x: A) extends Serializable {
+  
+  /*  
+    final def map[A1](f: A => A1): ControlContext[A1,B,C] = {
+      new ControlContext((k:(A1 => B)) => fun((x:A) => k(f(x))), null.asInstanceOf[A1])
+    }
+  
+    final def flatMap[A1,B1<:B](f: (A => ControlContext[A1,B1,B])): ControlContext[A1,B1,C] = {
+      new ControlContext((k:(A1 => B1)) => fun((x:A) => f(x).fun(k)))
+    }
+  */
+
+
+  @noinline final def map[A1](f: A => A1): ControlContext[A1,B,C] = {
+    if (fun eq null)
+      try {
+        new ControlContext(null, f(x)) // TODO: only alloc if f(x) != x
+      } catch {
+        case ex: Exception => 
+          new ControlContext((k: A1 => B, thr: Exception => B) => thr(ex).asInstanceOf[C], null.asInstanceOf[A1])
+      }
+    else
+      new ControlContext({ (k: A1 => B, thr: Exception => B) =>
+        fun( { (x:A) =>
+          var done = false
+          try {
+            val res = f(x)
+            done = true
+            k(res)
+          } catch {
+            case ex: Exception =>
+              if (!done) thr(ex) else throw ex
+          }
+        }, thr)
+      }, null.asInstanceOf[A1])
+  }
+  
+
+  // it would be nice if @inline would turn the trivial path into a tail call.
+  // unfortunately it doesn't, so we do it ourselves in SelectiveCPSTransform
+  
+  @noinline final def flatMap[A1,B1,C1<:B](f: (A => ControlContext[A1,B1,C1])): ControlContext[A1,B1,C] = {
+    if (fun eq null)
+      try {
+        f(x).asInstanceOf[ControlContext[A1,B1,C]]
+      } catch {
+        case ex: Exception => 
+          new ControlContext((k: A1 => B1, thr: Exception => B1) => thr(ex).asInstanceOf[C], null.asInstanceOf[A1])
+      }
+    else
+      new ControlContext({ (k: A1 => B1, thr: Exception => B1) =>
+        fun( { (x:A) =>
+          var done = false
+          try {
+            val ctxR = f(x)
+            done = true
+            val res: C1 = ctxR.foreachFull(k, thr) // => B1
+            res
+          } catch {
+            case ex: Exception =>
+              if (!done)
+                thr(ex).asInstanceOf[B] // => B NOTE: in general this is unsafe!
+              else throw ex
+          }                             // However, the plugin will not generate offending code
+        }, thr.asInstanceOf[Exception=>B]) // => B
+      }, null.asInstanceOf[A1])
+  }
+
+  final def foreach(f: A => B) = foreachFull(f, throw _)
+  
+  def foreachFull(f: A => B, g: Exception => B): C = {
+    if (fun eq null)
+      f(x).asInstanceOf[C]
+    else
+      fun(f, g)
+  }
+  
+
+  final def isTrivial = fun eq null
+  final def getTrivialValue = x.asInstanceOf[A]
+
+  // need filter or other functions?
+
+  final def flatMapCatch[A1>:A,B1<:B,C1>:C<:B1](pf: PartialFunction[Exception, ControlContext[A1,B1,C1]]): ControlContext[A1,B1,C1] = {
+    if (fun eq null)
+      this
+    else {
+      val fun1 = (ret1: A1 => B1, thr1: Exception => B1) => {
+        val thr: Exception => B1 = { t: Exception =>
+          var captureExceptions = true
+          try {
+            if (pf.isDefinedAt(t)) {
+              val cc1 = pf(t)
+              captureExceptions = false
+              cc1.foreachFull(ret1, thr1) // Throw => B
+            } else {
+              captureExceptions = false
+              thr1(t) // Throw => B1
+            }
+          } catch {
+            case t1: Exception => 
+              if (captureExceptions)
+                thr1(t1) // => E2
+              else throw t1
+          }
+        }
+        fun(ret1, thr)// fun(ret1, thr)  // => B
+      }
+      new ControlContext(fun1, null.asInstanceOf[A1])
+    }
+  }
+
+  final def mapFinally(f: () => Unit): ControlContext[A,B,C] = {
+    if (fun eq null) {
+      try {
+        f()
+        this
+      } catch {
+        case ex: Exception => 
+          new ControlContext((k: A => B, thr: Exception => B) => thr(ex).asInstanceOf[C], null.asInstanceOf[A])
+      }
+    } else {
+      val fun1 = (ret1: A => B, thr1: Exception => B) => {
+        val ret: A => B = { x: A =>
+          var captureExceptions = true
+          try {
+            f()
+            captureExceptions = false
+            ret1(x)
+          } catch {
+            case t1: Exception => 
+              if (captureExceptions)
+                thr1(t1)
+              else
+                throw t1
+          }
+        }
+        val thr: Exception => B = { t: Exception =>
+          var captureExceptions = true
+          try {
+            f()
+            captureExceptions = false
+            thr1(t)
+          } catch {
+            case t1: Exception =>
+              if (captureExceptions)
+                thr1(t1)
+              else throw t1
+          }
+        }
+        fun(ret, thr1)
+      }
+      new ControlContext(fun1, null.asInstanceOf[A])
+    }
+  }
+  
+}

--- a/src/jdk2ikvm/resources/replacements/scala/util/continuations/package.scala
+++ b/src/jdk2ikvm/resources/replacements/scala/util/continuations/package.scala
@@ -1,0 +1,125 @@
+// $Id$
+
+
+package scala.util
+
+/* TODO: better documentation of return-type modification.
+ * (Especially what means "Illegal answer type modification: ... andThen ...")
+ */
+
+/**
+ * Delimited continuations are a feature for modifying the usual control flow
+ * of a program.  To use continuations, provide the option `-P:continuations:enable`
+ * to the Scala compiler or REPL to activate the compiler plugin.
+ *
+ * Below is an example of using continuations to suspend execution while awaiting
+ * user input. Similar facilities are used in so-called continuation-based web frameworks.
+ *
+ * {{{
+ *   def go =
+ *     reset {
+ *       println("Welcome!")
+ *       val first = ask("Please give me a number")
+ *       val second = ask("Please enter another number")
+ *       printf("The sum of your numbers is: %d\n", first + second)
+ *     }
+ * }}}
+ *
+ * The `reset` is provided by this package and delimits the extent of the transformation.
+ * The `ask` is a function that will be defined below. Its effect is to issue a prompt
+ * and then suspend execution awaiting user input. Once the user provides an input value,
+ * execution of the suspended block resumes.
+ *
+ * {{{
+ *   val sessions = new HashMap[UUID, Int=>Unit]
+ *   def ask(prompt: String): Int @cps[Unit] =
+ *     shift {
+ *       k: (Int => Unit) => {
+ *         val id = uuidGen
+ *         printf("%s\nrespond with: submit(0x%x, ...)\n", prompt, id)
+ *         sessions += id -> k
+ *       }
+ *     }
+ * }}}
+ *
+ * The type of `ask` includes a `@cps` annotation which drives the transformation.
+ * The type signature `Int @cps[Unit]` means that `ask` should be used in a context
+ * requiring an `Int`, but actually it will suspend and return `Unit`.
+ *
+ * The computation leading up to the first `ask` is executed normally. The remainder
+ * of the reset block is wrapped into a closure that is passed as the parameter `k` to
+ * the `shift` function, which can then decide whether and how to execute the
+ * continuation. In this example, the continuation is stored in a sessions map for
+ * later execution. This continuation includes a second call to `ask`, which is treated
+ * likewise once the execution resumes.
+ *
+ * <h2>CPS Annotation</h2>
+ *
+ * The aforementioned `@cps[A]` annotation is an alias for the more general `@cpsParam[B,C]`
+ * where `B=C`. The type `A @cps[B,C]` describes a term which yields a value of type `A` within
+ * an evaluation context producing a value of type `B`. After the CPS transformation, this return
+ * type is modified to `C`.
+ *
+ * The `@cpsParam` annotations are introduced by `shift` blocks, and propagate via the return
+ * types to the dynamically enclosing context. The propagation stops upon reaching a `reset`
+ * block.
+ */
+
+package object continuations {
+
+  type cps[A] = cpsParam[A,A]
+  
+  type suspendable = cps[Unit]
+  
+
+  def shift[A,B,C](fun: (A => B) => C): A @cpsParam[B,C] = {
+    throw new RuntimeException("this code has to be compiled with the Scala continuations plugin enabled")
+  }
+
+  def reset[A,C](ctx: =>(A @cpsParam[A,C])): C = {
+    val ctxR = reify[A,A,C](ctx)
+    if (ctxR.isTrivial)
+      ctxR.getTrivialValue.asInstanceOf[C]
+    else
+      ctxR.foreach((x:A) => x)
+  }
+
+  def reset0[A](ctx: =>(A @cpsParam[A,A])): A = reset(ctx)
+
+  def run[A](ctx: =>(Any @cpsParam[Unit,A])): A = {
+    val ctxR = reify[Any,Unit,A](ctx)
+    if (ctxR.isTrivial)
+      ctxR.getTrivialValue.asInstanceOf[A]
+    else
+      ctxR.foreach((x:Any) => ())
+  }
+
+  
+  // methods below are primarily implementation details and are not
+  // needed frequently in client code
+
+  def shiftUnit0[A,B](x: A): A @cpsParam[B,B] = {
+    shiftUnit[A,B,B](x)
+  }
+
+  def shiftUnit[A,B,C>:B](x: A): A @cpsParam[B,C] = {
+    throw new RuntimeException("this code has to be compiled with the Scala continuations plugin enabled")
+  }
+
+  def reify[A,B,C](ctx: =>(A @cpsParam[B,C])): ControlContext[A,B,C] = {
+    throw new RuntimeException("this code has to be compiled with the Scala continuations plugin enabled")
+  }  
+
+  def shiftUnitR[A,B](x: A): ControlContext[A,B,B] = {
+    new ControlContext(null, x)
+  }
+
+  def shiftR[A,B,C](fun: (A => B) => C): ControlContext[A,B,C] = {
+    new ControlContext((f:A=>B,g:Exception=>B) => fun(f), null.asInstanceOf[A])
+  }
+
+  def reifyR[A,B,C](ctx: => ControlContext[A,B,C]): ControlContext[A,B,C] = {
+    ctx
+  }
+
+}


### PR DESCRIPTION
In order to do it cleanly we had to add support for
replacements for files not located in src/library
directory. Thus I refactored build.xml to first
assemble all scala files contributing to
scala-library-gwt.jar in one directory and only then
run jdk2ikvm tool on top of it.

While working on this I run into issue that simple
copying files from src/library to other directory
using Ant would make scala compiler to blow up
for some reason I don't understand. I decided to
go with a work-around by making a system call to
cp command that is capable of copying files in a way
that doesn't blow up scala compiler. This results
in platform-dependent build but I don't have enough
of time to fight this. Anyone interested in Windows
build can try to tackle this.

Added replacements for continuations library path that:
- add work-arounds for pattern matcher shortcomings
- replace NoSuchMethodException with RuntimeException

Signed-off-by: Grzegorz Kossakowski grzegorz.kossakowski@gmail.com
