### PR TITLE
Get rid of RedBlack.scala for a while.

### DIFF
--- a/src/jdk2ikvm/resources/replacements/scala/collection/immutable/SortedMap.scala
+++ b/src/jdk2ikvm/resources/replacements/scala/collection/immutable/SortedMap.scala
@@ -1,0 +1,92 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2011, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+
+
+package scala.collection
+package immutable
+
+import generic._
+import mutable.Builder
+import annotation.unchecked.uncheckedVariance
+import annotation.bridge
+
+/** A map whose keys are sorted.
+ *  
+ *  @tparam A     the type of the keys contained in this sorted map.
+ *  @tparam B     the type of the values associated with the keys.
+ *  
+ *  @author Sean McDirmid
+ *  @author Martin Odersky
+ *  @version 2.8
+ *  @since   2.4
+ *  @define Coll immutable.SortedMap
+ *  @define coll immutable sorted map
+ */
+trait SortedMap[A, +B] extends Map[A, B] 
+                         with scala.collection.SortedMap[A, B] 
+                         with MapLike[A, B, SortedMap[A, B]]
+                         with SortedMapLike[A, B, SortedMap[A, B]] { self =>
+
+  override protected[this] def newBuilder : Builder[(A, B), SortedMap[A, B]] = 
+    SortedMap.newBuilder[A, B]
+
+  override def empty: SortedMap[A, B] = SortedMap.empty
+  override def updated [B1 >: B](key: A, value: B1): SortedMap[A, B1] = this + ((key, value))
+  override def keySet: immutable.SortedSet[A] = new DefaultKeySortedSet
+  
+  protected class DefaultKeySortedSet extends super.DefaultKeySortedSet with immutable.SortedSet[A] {
+    override def + (elem: A): SortedSet[A] =
+      if (this(elem)) this
+      else SortedSet[A]() ++ this + elem    
+    override def - (elem: A): SortedSet[A] = 
+      if (this(elem)) SortedSet[A]() ++ this - elem
+      else this      
+    override def rangeImpl(from : Option[A], until : Option[A]) : SortedSet[A] = {
+      val map = self.rangeImpl(from, until)
+      new map.DefaultKeySortedSet
+    }
+  }
+
+  /** Add a key/value pair to this map. 
+   *  @param    kv the key/value pair
+   *  @return   A new map with the new binding added to this map
+   *  @note     needs to be overridden in subclasses
+   */
+  def + [B1 >: B](kv: (A, B1)): SortedMap[A, B1] = throw new AbstractMethodError("SortedMap.+")
+
+  /** Adds two or more elements to this collection and returns
+   *  a new collection.
+   *
+   *  @param elem1 the first element to add.
+   *  @param elem2 the second element to add.
+   *  @param elems the remaining elements to add.
+   */
+  override def + [B1 >: B] (elem1: (A, B1), elem2: (A, B1), elems: (A, B1) *): SortedMap[A, B1] =
+    this + elem1 + elem2 ++ elems
+
+  /** Adds a number of elements provided by a traversable object
+   *  and returns a new collection with the added elements.
+   *
+   *  @param xs     the traversable object.
+   */
+  override def ++[B1 >: B](xs: GenTraversableOnce[(A, B1)]): SortedMap[A, B1] = 
+    ((repr: SortedMap[A, B1]) /: xs.seq) (_ + _)
+
+  @bridge def ++[B1 >: B](xs: TraversableOnce[(A, B1)]): SortedMap[A, B1] = ++(xs: GenTraversableOnce[(A, B1)])
+}
+
+/** $factoryInfo
+ *  @define Coll immutable.SortedMap
+ *  @define coll immutable sorted map
+ */
+object SortedMap extends ImmutableSortedMapFactory[SortedMap] {
+  /** $sortedMapCanBuildFromInfo */
+  implicit def canBuildFrom[A, B](implicit ord: Ordering[A]): CanBuildFrom[Coll, (A, B), SortedMap[A, B]] = new SortedMapCanBuildFrom[A, B]
+  def empty[A, B](implicit ord: Ordering[A]): SortedMap[A, B] = sys.error("TreeMap is not supported due to bugs. We're working on a fix.")
+}

--- a/src/jdk2ikvm/resources/replacements/scala/collection/immutable/SortedSet.scala
+++ b/src/jdk2ikvm/resources/replacements/scala/collection/immutable/SortedSet.scala
@@ -1,0 +1,40 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2011, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+
+
+package scala.collection
+package immutable
+
+import generic._
+import mutable.Builder
+
+/** A subtrait of `collection.SortedSet` which represents sorted sets
+ *  which cannot be mutated.
+ *
+ *  @author Sean McDirmid
+ *  @author Martin Odersky
+ *  @version 2.8
+ *  @since   2.4
+ *  @define Coll immutable.SortedSet
+ *  @define coll immutable sorted set
+ */
+trait SortedSet[A] extends Set[A] with scala.collection.SortedSet[A] with SortedSetLike[A, SortedSet[A]] {
+  /** Needs to be overridden in subclasses. */
+  override def empty: SortedSet[A] = SortedSet.empty[A]
+}
+
+/** $factoryInfo
+ *  @define Coll immutable.SortedSet
+ *  @define coll immutable sorted set
+ */
+object SortedSet extends ImmutableSortedSetFactory[SortedSet] {
+  /** $sortedSetCanBuildFromInfo */
+  implicit def canBuildFrom[A](implicit ord: Ordering[A]): CanBuildFrom[Coll, A, SortedSet[A]] = new SortedSetCanBuildFrom[A]
+  def empty[A](implicit ord: Ordering[A]): SortedSet[A] = sys.error("TreeSet is not supported due to bugs. We're working on a fix.")
+}

--- a/src/jdk2ikvm/src/scala/tools/jdk2ikvm/JDK2IKVM.scala
+++ b/src/jdk2ikvm/src/scala/tools/jdk2ikvm/JDK2IKVM.scala
@@ -93,6 +93,12 @@ abstract class JDK2IKVM
             "scala/collection/generic/ParSetFactory.scala",
             "scala/collection/generic/CanCombineFrom.scala",
             "scala/collection/generic/HasNewCombiner.scala",
+            //breaks GWT due to bugs in scala (broken signatures) and bugs in jribble backend (broken jribble output)
+            //excluding it for now
+            "scala/collection/immutable/RedBlack.scala",
+            //TreeMap and TreeSet depend on RedBlack.scala
+            "scala/collection/immutable/TreeMap.scala",
+            "scala/collection/immutable/TreeSet.scala",
             //depends on threads
             "scala/collection/generic/Signalling.scala",
             //depends on scala.io


### PR DESCRIPTION
As a work-around for various bugs let's get rid of
RedBlack.scala completely until those are fixed.

I'll recheck this patch once we merge in latest Scala
trunk.

Signed-off-by: Grzegorz Kossakowski grzegorz.kossakowski@gmail.com
