### PR TITLE
Add missing break statements in switch cases.

### DIFF
--- a/test/files/jribble/patternmatching.check/PatternMatching.jribble
+++ b/test/files/jribble/patternmatching.check/PatternMatching.jribble
@@ -188,6 +188,11 @@ member {
                       }
                     }
                   }
+                  statement {
+                    type: Break
+                    break {
+                    }
+                  }
                 }
               }
             }
@@ -218,6 +223,11 @@ member {
                           }
                         }
                       }
+                    }
+                  }
+                  statement {
+                    type: Break
+                    break {
                     }
                   }
                 }
@@ -252,6 +262,11 @@ member {
                       }
                     }
                   }
+                  statement {
+                    type: Break
+                    break {
+                    }
+                  }
                 }
               }
             }
@@ -277,6 +292,11 @@ member {
                         }
                       }
                     }
+                  }
+                }
+                statement {
+                  type: Break
+                  break {
                   }
                 }
               }


### PR DESCRIPTION
Jribble follows Java/C semantics of switch/case
statement so we need to insert break statements
when translating from scala.

Signed-off-by: Grzegorz Kossakowski grzegorz.kossakowski@gmail.com
