### PR TITLE
Fix for refArrayOps call to use ClassManifest.

### DIFF
--- a/src/jdk2ikvm/resources/replacements/README.txt
+++ b/src/jdk2ikvm/resources/replacements/README.txt
@@ -24,6 +24,14 @@ scala/collection/immutable/StringLike.scala
 Depends on String.format. I found it easier to patch it by hand. Should be removed from here
 ASAP.
 
+scala/collection/mutable/ArrayOps.scala
+-----------------------------------------
+Removes references to parallel collections and adds context bound on ClassManifest for
+ofRef class so we can get rid of "ClassManifest.classType[T](repr.getClass.getComponentType))"
+call that relies on refleciton. Ideally, this functionality should be implemented as a patch
+but our current patching mechanism lacks support for adding context bounds so it was easier
+to just add a replacement for the whole file.
+
 scala/collection/mutable/BufferLike.scala
 -----------------------------------------
 Creepy one. Since in GWT there's one Object.clone() method Scala compiler gets really confused

--- a/src/jdk2ikvm/resources/replacements/scala/collection/mutable/ArrayOps.scala
+++ b/src/jdk2ikvm/resources/replacements/scala/collection/mutable/ArrayOps.scala
@@ -1,0 +1,222 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2002-2011, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+
+
+package scala.collection
+package mutable
+import compat.Platform.arraycopy
+
+import scala.reflect.ClassManifest
+
+
+/** This class serves as a wrapper for `Array`s with all the operations found in
+ *  indexed sequences. Where needed, instances of arrays are implicitly converted
+ *  into this class.
+ *  
+ *  The difference between this class and `WrappedArray` is that calling transformer
+ *  methods such as `filter` and `map` will yield an array, whereas a `WrappedArray`
+ *  will remain a `WrappedArray`.
+ *  
+ *  @since 2.8
+ *  
+ *  @tparam T   type of the elements contained in this array.
+ *  
+ *  @define Coll ArrayOps
+ *  @define orderDependent 
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
+abstract class ArrayOps[T] extends ArrayLike[T, Array[T]] {
+
+  private def rowBuilder[U]: Builder[U, Array[U]] = 
+    Array.newBuilder(
+      ClassManifest.fromClass(
+        repr.getClass.getComponentType.getComponentType.asInstanceOf[Predef.Class[U]]))
+
+  override def copyToArray[U >: T](xs: Array[U], start: Int, len: Int) {
+    var l = math.min(len, repr.length)
+    if (xs.length - start < l) l = xs.length - start max 0 
+    Array.copy(repr, 0, xs, start, l)
+  }
+
+  override def toArray[U >: T : ClassManifest]: Array[U] =
+    if (implicitly[ClassManifest[U]].erasure eq repr.getClass.getComponentType)
+      repr.asInstanceOf[Array[U]]
+    else 
+      super.toArray[U]
+  
+  /** Flattens a two-dimensional array by concatenating all its rows
+   *  into a single array.
+   *  
+   *  @tparam U        Type of row elements.
+   *  @param asArray   A function that converts elements of this array to rows - arrays of type `U`.
+   *  @return          An array obtained by concatenating rows of this array.
+   */
+  def flatten[U, To](implicit asTrav: T => collection.Traversable[U], m: ClassManifest[U]): Array[U] = {
+    val b = Array.newBuilder[U]
+    b.sizeHint(map{case is: IndexedSeq[_] => is.size case _ => 0} sum)
+    for (xs <- this)
+      b ++= asTrav(xs)
+    b.result
+  }
+
+  /** Transposes a two dimensional array.
+   *  
+   *  @tparam U       Type of row elements.
+   *  @param asArray  A function that converts elements of this array to rows - arrays of type `U`.
+   *  @return         An array obtained by replacing elements of this arrays with rows the represent.
+   */
+  def transpose[U](implicit asArray: T => Array[U]): Array[Array[U]] = {
+    val bs = asArray(head) map (_ => rowBuilder[U])
+    for (xs <- this) {
+      var i = 0
+      for (x <- asArray(xs)) {
+        bs(i) += x
+        i += 1
+      }
+    }
+    val bb: Builder[Array[U], Array[Array[U]]] = Array.newBuilder(
+      ClassManifest.fromClass(
+        repr.getClass.getComponentType.asInstanceOf[Predef.Class[Array[U]]]))
+    for (b <- bs) bb += b.result
+    bb.result
+  }
+  
+  def seq = this.iterator
+  
+}
+
+/**
+ * A companion object for `ArrayOps`.
+ * 
+ * @since 2.8
+ */
+object ArrayOps {
+
+  /** A class of `ArrayOps` for arrays containing reference types. */
+  class ofRef[T <: AnyRef : ClassManifest](override val repr: Array[T]) extends ArrayOps[T] with ArrayLike[T, Array[T]] {
+
+    override protected[this] def thisCollection: WrappedArray[T] = new WrappedArray.ofRef[T](repr)
+    override protected[this] def toCollection(repr: Array[T]): WrappedArray[T] = new WrappedArray.ofRef[T](repr)
+    override protected[this] def newBuilder = new ArrayBuilder.ofRef[T]
+
+    def length: Int = repr.length
+    def apply(index: Int): T = repr(index)
+    def update(index: Int, elem: T) { repr(index) = elem }
+  } 
+  
+  /** A class of `ArrayOps` for arrays containing `byte`s. */
+  class ofByte(override val repr: Array[Byte]) extends ArrayOps[Byte] with ArrayLike[Byte, Array[Byte]] {
+
+    override protected[this] def thisCollection: WrappedArray[Byte] = new WrappedArray.ofByte(repr)
+    override protected[this] def toCollection(repr: Array[Byte]): WrappedArray[Byte] = new WrappedArray.ofByte(repr)
+    override protected[this] def newBuilder = new ArrayBuilder.ofByte
+
+    def length: Int = repr.length
+    def apply(index: Int): Byte = repr(index)
+    def update(index: Int, elem: Byte) { repr(index) = elem }
+  } 
+
+  /** A class of `ArrayOps` for arrays containing `short`s. */
+  class ofShort(override val repr: Array[Short]) extends ArrayOps[Short] with ArrayLike[Short, Array[Short]] {
+
+    override protected[this] def thisCollection: WrappedArray[Short] = new WrappedArray.ofShort(repr)
+    override protected[this] def toCollection(repr: Array[Short]): WrappedArray[Short] = new WrappedArray.ofShort(repr)
+    override protected[this] def newBuilder = new ArrayBuilder.ofShort
+
+    def length: Int = repr.length
+    def apply(index: Int): Short = repr(index)
+    def update(index: Int, elem: Short) { repr(index) = elem }
+  } 
+
+  /** A class of `ArrayOps` for arrays containing `char`s. */
+  class ofChar(override val repr: Array[Char]) extends ArrayOps[Char] with ArrayLike[Char, Array[Char]] {
+
+    override protected[this] def thisCollection: WrappedArray[Char] = new WrappedArray.ofChar(repr)
+    override protected[this] def toCollection(repr: Array[Char]): WrappedArray[Char] = new WrappedArray.ofChar(repr)
+    override protected[this] def newBuilder = new ArrayBuilder.ofChar
+
+    def length: Int = repr.length
+    def apply(index: Int): Char = repr(index)
+    def update(index: Int, elem: Char) { repr(index) = elem }
+  } 
+
+  /** A class of `ArrayOps` for arrays containing `int`s. */
+  class ofInt(override val repr: Array[Int]) extends ArrayOps[Int] with ArrayLike[Int, Array[Int]] {
+
+    override protected[this] def thisCollection: WrappedArray[Int] = new WrappedArray.ofInt(repr)
+    override protected[this] def toCollection(repr: Array[Int]): WrappedArray[Int] = new WrappedArray.ofInt(repr)
+    override protected[this] def newBuilder = new ArrayBuilder.ofInt
+
+    def length: Int = repr.length
+    def apply(index: Int): Int = repr(index)
+    def update(index: Int, elem: Int) { repr(index) = elem }
+  } 
+
+  /** A class of `ArrayOps` for arrays containing `long`s. */
+  class ofLong(override val repr: Array[Long]) extends ArrayOps[Long] with ArrayLike[Long, Array[Long]] {
+
+    override protected[this] def thisCollection: WrappedArray[Long] = new WrappedArray.ofLong(repr)
+    override protected[this] def toCollection(repr: Array[Long]): WrappedArray[Long] = new WrappedArray.ofLong(repr)
+    override protected[this] def newBuilder = new ArrayBuilder.ofLong
+
+    def length: Int = repr.length
+    def apply(index: Int): Long = repr(index)
+    def update(index: Int, elem: Long) { repr(index) = elem }
+  } 
+
+  /** A class of `ArrayOps` for arrays containing `float`s. */
+  class ofFloat(override val repr: Array[Float]) extends ArrayOps[Float] with ArrayLike[Float, Array[Float]] {
+
+    override protected[this] def thisCollection: WrappedArray[Float] = new WrappedArray.ofFloat(repr)
+    override protected[this] def toCollection(repr: Array[Float]): WrappedArray[Float] = new WrappedArray.ofFloat(repr)
+    override protected[this] def newBuilder = new ArrayBuilder.ofFloat
+
+    def length: Int = repr.length
+    def apply(index: Int): Float = repr(index)
+    def update(index: Int, elem: Float) { repr(index) = elem }
+  } 
+
+  /** A class of `ArrayOps` for arrays containing `double`s. */
+  class ofDouble(override val repr: Array[Double]) extends ArrayOps[Double] with ArrayLike[Double, Array[Double]] {
+
+    override protected[this] def thisCollection: WrappedArray[Double] = new WrappedArray.ofDouble(repr)
+    override protected[this] def toCollection(repr: Array[Double]): WrappedArray[Double] = new WrappedArray.ofDouble(repr)
+    override protected[this] def newBuilder = new ArrayBuilder.ofDouble
+
+    def length: Int = repr.length
+    def apply(index: Int): Double = repr(index)
+    def update(index: Int, elem: Double) { repr(index) = elem }
+  } 
+
+  /** A class of `ArrayOps` for arrays containing `boolean`s. */
+  class ofBoolean(override val repr: Array[Boolean]) extends ArrayOps[Boolean] with ArrayLike[Boolean, Array[Boolean]] {
+
+    override protected[this] def thisCollection: WrappedArray[Boolean] = new WrappedArray.ofBoolean(repr)
+    override protected[this] def toCollection(repr: Array[Boolean]): WrappedArray[Boolean] = new WrappedArray.ofBoolean(repr)
+    override protected[this] def newBuilder = new ArrayBuilder.ofBoolean
+
+    def length: Int = repr.length
+    def apply(index: Int): Boolean = repr(index)
+    def update(index: Int, elem: Boolean) { repr(index) = elem }
+  } 
+
+  /** A class of `ArrayOps` for arrays of `Unit` types. */
+  class ofUnit(override val repr: Array[Unit]) extends ArrayOps[Unit] with ArrayLike[Unit, Array[Unit]] {
+
+    override protected[this] def thisCollection: WrappedArray[Unit] = new WrappedArray.ofUnit(repr)
+    override protected[this] def toCollection(repr: Array[Unit]): WrappedArray[Unit] = new WrappedArray.ofUnit(repr)
+    override protected[this] def newBuilder = new ArrayBuilder.ofUnit
+
+    def length: Int = repr.length
+    def apply(index: Int): Unit = repr(index)
+    def update(index: Int, elem: Unit) { repr(index) = elem }
+  } 
+}

--- a/src/jdk2ikvm/src/scala/tools/jdk2ikvm/gwt/patchcmds/Generating.scala
+++ b/src/jdk2ikvm/src/scala/tools/jdk2ikvm/gwt/patchcmds/Generating.scala
@@ -345,6 +345,9 @@ trait Generating extends Patching { this : Plugin =>
       //probably a call to Console.read*
       case x: DefDef if x.name startsWith "read" =>
         removeDefDef(x)
+      case x: DefDef if x.name.toString == "refArrayOps" =>
+        val range = rangePosition(x.pos).get
+        patchtree.replace(range.start, range.end, "implicit def refArrayOps[T <: AnyRef: ClassManifest](xs: Array[T]): ArrayOps[T] = new ArrayOps.ofRef[T](xs)\n")
     }
     
   }


### PR DESCRIPTION
We make implicit def refArrayOps in Predef to
require ClassManifest instead of relying on
reflection tricks.

NOTE: This change has been incorporated in
0.1-M1 release but got dropped by accident.
Resumbitting it.

Signed-off-by: Grzegorz Kossakowski grzegorz.kossakowski@gmail.com
