### PR TITLE
When emitting Jribble for a catch clause, use the symbol's name

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jribble/ProtobufConverter.scala
+++ b/src/compiler/scala/tools/nsc/backend/jribble/ProtobufConverter.scala
@@ -465,7 +465,7 @@ abstract class ProtobufConverter extends AnyRef with JribbleAnalysis {
         val tpe: P.Type = convert(exBinding.symbol.tpe)
         assert(tpe.getType == P.Type.TypeType.Named)
         proto.setTpe(tpe.getNamedType)
-        proto.setParam(exName.encode.toString)
+        proto.setParam(exBinding.symbol.name.encode.toString)
         
       case CaseDef(Typed(Ident(nme.WILDCARD), tpt), _, catchBody) =>
         val tpe: P.Type = convert(tpt.tpe)

--- a/test/files/jribble/try.check/Try$$anonfun$1.jribble
+++ b/test/files/jribble/try.check/Try$$anonfun$1.jribble
@@ -1,0 +1,209 @@
+name {
+  name: "Try$$anonfun$1"
+}
+modifiers {
+  isPublic: true
+  isFinal: true
+}
+ext {
+  pkg: "scala.runtime"
+  name: "AbstractFunction0"
+}
+implements {
+  pkg: "scala"
+  name: "Serializable"
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+    isFinal: true
+  }
+  method {
+    name: "apply"
+    returnType {
+      type: Named
+      namedType {
+        pkg: "java.lang"
+        name: "Exception"
+      }
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: FieldRef
+              fieldRef {
+                qualifier {
+                  type: ThisRef
+                }
+                enclosingType {
+                  name: "Try$$anonfun$1"
+                }
+                name: "ex$2"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+    isFinal: true
+  }
+  method {
+    name: "apply"
+    returnType {
+      type: Named
+      namedType {
+        pkg: "java.lang"
+        name: "Object"
+      }
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: MethodCall
+              methodCall {
+                receiver {
+                  type: ThisRef
+                }
+                signature {
+                  name: "apply"
+                  owner {
+                    name: "Try$$anonfun$1"
+                  }
+                  returnType {
+                    type: Named
+                    namedType {
+                      pkg: "java.lang"
+                      name: "Exception"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Field
+  modifiers {
+    isPrivate: true
+  }
+  fieldDef {
+    tpe {
+      type: Named
+      namedType {
+        pkg: "java.lang"
+        name: "Exception"
+      }
+    }
+    name: "ex$2"
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    isConstructor: true
+    name: "new"
+    paramDef {
+      name: "$outer"
+      tpe {
+        type: Named
+        namedType {
+          name: "Try"
+        }
+      }
+    }
+    paramDef {
+      name: "ex$2"
+      tpe {
+        type: Named
+        namedType {
+          pkg: "java.lang"
+          name: "Exception"
+        }
+      }
+    }
+    returnType {
+      type: Named
+      namedType {
+        name: "Try$$anonfun$1"
+      }
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Expr
+          expr {
+            type: Assignment
+            assignment {
+              lhs {
+                type: FieldRef
+                fieldRef {
+                  qualifier {
+                    type: ThisRef
+                  }
+                  enclosingType {
+                    name: "Try$$anonfun$1"
+                  }
+                  name: "ex$2"
+                }
+              }
+              rhs {
+                type: VarRef
+                varRef {
+                  name: "ex$2"
+                }
+              }
+            }
+          }
+        }
+        statement {
+          type: Expr
+          expr {
+            type: MethodCall
+            methodCall {
+              receiver {
+                type: ThisRef
+              }
+              signature {
+                name: "new"
+                owner {
+                  pkg: "scala.runtime"
+                  name: "AbstractFunction0"
+                }
+                returnType {
+                  type: Named
+                  namedType {
+                    pkg: "scala.runtime"
+                    name: "AbstractFunction0"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/files/jribble/try.check/Try.jribble
+++ b/test/files/jribble/try.check/Try.jribble
@@ -534,6 +534,100 @@ member {
 member {
   type: Method
   modifiers {
+    isPublic: true
+  }
+  method {
+    name: "catchAndPassToLambda"
+    returnType {
+      type: Void
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Try
+          tryStat {
+            block {
+              type: Block
+              block {
+              }
+            }
+            catch {
+              tpe {
+                pkg: "java.lang"
+                name: "Exception"
+              }
+              param: "ex$2"
+              body {
+                type: Block
+                block {
+                  statement {
+                    type: VarDef
+                    varDef {
+                      tpe {
+                        type: Named
+                        namedType {
+                          pkg: "scala"
+                          name: "Function0"
+                        }
+                      }
+                      name: "f"
+                      initializer {
+                        type: NewObject
+                        newObject {
+                          clazz {
+                            name: "Try$$anonfun$1"
+                          }
+                          signature {
+                            name: "new"
+                            owner {
+                              name: "Try$$anonfun$1"
+                            }
+                            paramType {
+                              type: Named
+                              namedType {
+                                name: "Try"
+                              }
+                            }
+                            paramType {
+                              type: Named
+                              namedType {
+                                pkg: "java.lang"
+                                name: "Exception"
+                              }
+                            }
+                            returnType {
+                              type: Named
+                              namedType {
+                                name: "Try$$anonfun$1"
+                              }
+                            }
+                          }
+                          argument {
+                            type: ThisRef
+                          }
+                          argument {
+                            type: VarRef
+                            varRef {
+                              name: "ex$2"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
     isPrivate: true
     isFinal: true
   }

--- a/test/files/jribble/try.scala
+++ b/test/files/jribble/try.scala
@@ -20,4 +20,9 @@ class Try {
   def tryPlusFinally {
     try { true } finally { println("finally") }
   }
+
+  def catchAndPassToLambda {
+    try { true } catch { case ex: Exception => val f = () => ex }
+  }
+
 }


### PR DESCRIPTION
of the variable rather than the AST's name for it.

Added test-case for problem mentioned in #38.

Fixes #38.

Signed-off-by: Grzegorz Kossakowski grzegorz.kossakowski@gmail.com
