### PR TITLE
Update versions used in build to include scalagwt

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -234,7 +234,7 @@ INITIALISATION
     <property file="${basedir}/build.number"/>
     <property
       name="version.number"
-      value="${version.major}.${version.minor}.${version.patch}.r${svn.number}-b${time.short}"/>
+      value="${version.major}.${version.minor}.${version.patch}-scalagwt.r${svn.number}-b${time.short}"/>
     <!-- And print-out what we are building -->
     <echo level="info" message="Build number is '${version.number}'"/>
     <echo level="info" message="Built ${time.human} from revision ${svn.number} with ${java.vm.name} ${java.version}"/>

--- a/src/build/pack.xml
+++ b/src/build/pack.xml
@@ -286,7 +286,7 @@ MAIN DISTRIBUTION SBAZ
           file="${src.dir}/build/maven/maven-deploy.xml"/>
     <!-- export properties for use when deploying -->
     <property name="maven.snapshot.version.number"
-              value="${version.major}.${version.minor}.${version.patch}-SNAPSHOT"/>
+              value="${version.major}.${version.minor}.${version.patch}-scalagwt-SNAPSHOT"/>
     <echoproperties destfile="${dists.dir}/maven/${version.number}/build.properties"/>
   </target>
 

--- a/tools/get-scala-revision
+++ b/tools/get-scala-revision
@@ -15,16 +15,5 @@ fi
 
 cd $DIR
 
-if [ -d .svn ]; then
-  # 2>&1 to catch also error output (e.g. svn warnings)
-  svn info . 2>&1 | grep ^Revision | sed 's/Revision: //'
-elif [ -d .git ]; then
-  GIT_PAGER=cat
-  # this grabs more than one line because otherwise if you have local
-  # commits which aren't in git-svn it won't see any revision.
-  git log -10 | grep git-svn-id | head -1 | sed 's/[^@]*@\([0-9]*\).*/\1/'
-else
-  echo "${DIR} doesn't appear to be git or svn dir." >&2
-  echo 0
-  exit 1
-fi
+#scalagwt uses git
+git describe --always


### PR DESCRIPTION
We should include scalagwt identifier in build
numbers so we can identify jars built for
scalagwt project.

Updated get-scala-revision to use Git.

Signed-off-by: Grzegorz Kossakowski grzegorz.kossakowski@gmail.com
