### PR TITLE
Transforming boolean or's and and's to if else blocks to preserve lazy evaluation.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jribble/JribbleAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/backend/jribble/JribbleAnalysis.scala
@@ -80,6 +80,15 @@ trait JribbleAnalysis {
     isPrimitive(sym) && scalaPrimitives.isCoercion(getPrimitive(sym))
   }
 
+  def isBooleanOr(sym: Symbol): Boolean = {
+    import scalaPrimitives._
+    isPrimitive(sym) && (getPrimitive(sym) == ZOR)
+  }
+
+  def isBooleanAnd(sym: Symbol): Boolean = {
+    import scalaPrimitives._
+    isPrimitive(sym) && (getPrimitive(sym) == ZAND)
+  }
 
   def isInterface(sym: Symbol): Boolean = sym.hasFlag(INTERFACE)
 

--- a/src/compiler/scala/tools/nsc/backend/jribble/JribbleNormalization.scala
+++ b/src/compiler/scala/tools/nsc/backend/jribble/JribbleNormalization.scala
@@ -98,4 +98,6 @@ with JribbleAnalysis
     DefDef(sym, mods, List(params), rhs)
 
   val unitLiteral = Literal(Constant()) setType UnitClass.tpe
+  val trueLiteral = Literal(Constant(true)) setType BooleanClass.tpe
+  val falseLiteral = Literal(Constant(false)) setType BooleanClass.tpe
 }

--- a/test/files/jribble/binaryOperators.check/Test.jribbletxt
+++ b/test/files/jribble/binaryOperators.check/Test.jribbletxt
@@ -1,0 +1,404 @@
+name {
+  name: "Test"
+}
+modifiers {
+  isPublic: true
+}
+ext {
+  pkg: "java.lang"
+  name: "Object"
+}
+implements {
+  pkg: "scala"
+  name: "ScalaObject"
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "testCaseOr"
+    returnType {
+      type: Primitive
+      primitiveType: Boolean
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: Literal
+              literal {
+                type: Boolean
+                boolValue: true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "testCaseAnd"
+    returnType {
+      type: Primitive
+      primitiveType: Boolean
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: Literal
+              literal {
+                type: Boolean
+                boolValue: false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "testCaseOrComplex"
+    returnType {
+      type: Primitive
+      primitiveType: Boolean
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: Binary
+              binary {
+                op: Or
+                lhs {
+                  type: Binary
+                  binary {
+                    op: Or
+                    lhs {
+                      type: MethodCall
+                      methodCall {
+                        receiver {
+                          type: ThisRef
+                        }
+                        signature {
+                          name: "callA"
+                          owner {
+                            name: "Test"
+                          }
+                          returnType {
+                            type: Primitive
+                            primitiveType: Boolean
+                          }
+                        }
+                      }
+                    }
+                    rhs {
+                      type: MethodCall
+                      methodCall {
+                        receiver {
+                          type: ThisRef
+                        }
+                        signature {
+                          name: "callB"
+                          owner {
+                            name: "Test"
+                          }
+                          returnType {
+                            type: Primitive
+                            primitiveType: Boolean
+                          }
+                        }
+                      }
+                    }
+                    tpe {
+                      type: Primitive
+                      primitiveType: Boolean
+                    }
+                  }
+                }
+                rhs {
+                  type: MethodCall
+                  methodCall {
+                    receiver {
+                      type: ThisRef
+                    }
+                    signature {
+                      name: "callC"
+                      owner {
+                        name: "Test"
+                      }
+                      returnType {
+                        type: Primitive
+                        primitiveType: Boolean
+                      }
+                    }
+                  }
+                }
+                tpe {
+                  type: Primitive
+                  primitiveType: Boolean
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "testCaseAndComplex"
+    returnType {
+      type: Primitive
+      primitiveType: Boolean
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: Binary
+              binary {
+                op: And
+                lhs {
+                  type: Binary
+                  binary {
+                    op: And
+                    lhs {
+                      type: MethodCall
+                      methodCall {
+                        receiver {
+                          type: ThisRef
+                        }
+                        signature {
+                          name: "callA"
+                          owner {
+                            name: "Test"
+                          }
+                          returnType {
+                            type: Primitive
+                            primitiveType: Boolean
+                          }
+                        }
+                      }
+                    }
+                    rhs {
+                      type: MethodCall
+                      methodCall {
+                        receiver {
+                          type: ThisRef
+                        }
+                        signature {
+                          name: "callB"
+                          owner {
+                            name: "Test"
+                          }
+                          returnType {
+                            type: Primitive
+                            primitiveType: Boolean
+                          }
+                        }
+                      }
+                    }
+                    tpe {
+                      type: Primitive
+                      primitiveType: Boolean
+                    }
+                  }
+                }
+                rhs {
+                  type: MethodCall
+                  methodCall {
+                    receiver {
+                      type: ThisRef
+                    }
+                    signature {
+                      name: "callC"
+                      owner {
+                        name: "Test"
+                      }
+                      returnType {
+                        type: Primitive
+                        primitiveType: Boolean
+                      }
+                    }
+                  }
+                }
+                tpe {
+                  type: Primitive
+                  primitiveType: Boolean
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "callA"
+    returnType {
+      type: Primitive
+      primitiveType: Boolean
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: Literal
+              literal {
+                type: Boolean
+                boolValue: true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "callB"
+    returnType {
+      type: Primitive
+      primitiveType: Boolean
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: Literal
+              literal {
+                type: Boolean
+                boolValue: false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "callC"
+    returnType {
+      type: Primitive
+      primitiveType: Boolean
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: Literal
+              literal {
+                type: Boolean
+                boolValue: true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    isConstructor: true
+    name: "new"
+    returnType {
+      type: Named
+      namedType {
+        name: "Test"
+      }
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Expr
+          expr {
+            type: MethodCall
+            methodCall {
+              receiver {
+                type: ThisRef
+              }
+              signature {
+                name: "new"
+                owner {
+                  pkg: "java.lang"
+                  name: "Object"
+                }
+                returnType {
+                  type: Named
+                  namedType {
+                    pkg: "java.lang"
+                    name: "Object"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/files/jribble/binaryOperators.scala
+++ b/test/files/jribble/binaryOperators.scala
@@ -1,0 +1,12 @@
+class Test {
+
+  def testCaseOr = { true || true }
+  def testCaseAnd = { false && true }
+  def testCaseOrComplex = { callA || callB || callC }
+  def testCaseAndComplex = { callA && callB && callC }
+
+  def callA = true
+  def callB = false
+  def callC = true
+
+}

--- a/test/files/jribble/caseclass.check/CaseClass$.jribbletxt
+++ b/test/files/jribble/caseclass.check/CaseClass$.jribbletxt
@@ -87,7 +87,7 @@ member {
                 name: "Option"
               }
             }
-            name: "$2$"
+            name: "$5$"
           }
         }
         statement {
@@ -146,7 +146,7 @@ member {
                       lhs {
                         type: VarRef
                         varRef {
-                          name: "$2$"
+                          name: "$5$"
                         }
                       }
                       rhs {
@@ -182,7 +182,7 @@ member {
                       lhs {
                         type: VarRef
                         varRef {
-                          name: "$2$"
+                          name: "$5$"
                         }
                       }
                       rhs {
@@ -272,7 +272,7 @@ member {
             expression {
               type: VarRef
               varRef {
-                name: "$2$"
+                name: "$5$"
               }
             }
           }

--- a/test/files/jribble/caseclass.check/CaseClass.jribbletxt
+++ b/test/files/jribble/caseclass.check/CaseClass.jribbletxt
@@ -811,62 +811,77 @@ member {
           type: VarDef
           varDef {
             tpe {
-              type: Named
-              namedType {
-                name: "CaseClass"
-              }
+              type: Primitive
+              primitiveType: Boolean
             }
-            name: "CaseClass$1"
-            initializer {
-              type: Cast
-              cast {
-                expr {
+            name: "$3$"
+          }
+        }
+        statement {
+          type: If
+          ifStat {
+            condition {
+              type: Binary
+              binary {
+                op: Equal
+                lhs {
+                  type: ThisRef
+                }
+                rhs {
                   type: VarRef
                   varRef {
                     name: "x$1"
                   }
                 }
                 tpe {
-                  type: Named
-                  namedType {
-                    name: "CaseClass"
+                  type: Primitive
+                  primitiveType: Boolean
+                }
+              }
+            }
+            then {
+              type: Block
+              block {
+                statement {
+                  type: Expr
+                  expr {
+                    type: Assignment
+                    assignment {
+                      lhs {
+                        type: VarRef
+                        varRef {
+                          name: "$3$"
+                        }
+                      }
+                      rhs {
+                        type: Literal
+                        literal {
+                          type: Boolean
+                          boolValue: true
+                        }
+                      }
+                    }
                   }
                 }
               }
             }
-          }
-        }
-        statement {
-          type: Return
-          returnStat {
-            expression {
-              type: Binary
-              binary {
-                op: Or
-                lhs {
-                  type: Binary
-                  binary {
-                    op: Equal
-                    lhs {
-                      type: ThisRef
-                    }
-                    rhs {
-                      type: VarRef
-                      varRef {
-                        name: "x$1"
-                      }
-                    }
+            elsee {
+              type: Block
+              block {
+                statement {
+                  type: VarDef
+                  varDef {
                     tpe {
                       type: Primitive
                       primitiveType: Boolean
                     }
+                    name: "$4$"
                   }
                 }
-                rhs {
-                  type: Binary
-                  binary {
-                    op: And
-                    lhs {
+                statement {
+                  type: If
+                  ifStat {
+                    condition {
                       type: InstanceOf
                       instanceOf {
                         expr {
@@ -883,106 +898,203 @@ member {
                         }
                       }
                     }
-                    rhs {
-                      type: Binary
-                      binary {
-                        op: And
-                        lhs {
-                          type: Binary
-                          binary {
-                            op: Equal
-                            lhs {
-                              type: MethodCall
-                              methodCall {
-                                receiver {
-                                  type: ThisRef
-                                }
-                                signature {
-                                  name: "x"
-                                  owner {
-                                    name: "CaseClass"
-                                  }
-                                  returnType {
-                                    type: Primitive
-                                    primitiveType: Int
-                                  }
-                                }
-                              }
-                            }
-                            rhs {
-                              type: MethodCall
-                              methodCall {
-                                receiver {
-                                  type: VarRef
-                                  varRef {
-                                    name: "CaseClass$1"
-                                  }
-                                }
-                                signature {
-                                  name: "x"
-                                  owner {
-                                    name: "CaseClass"
-                                  }
-                                  returnType {
-                                    type: Primitive
-                                    primitiveType: Int
-                                  }
-                                }
-                              }
-                            }
+                    then {
+                      type: Block
+                      block {
+                        statement {
+                          type: VarDef
+                          varDef {
                             tpe {
-                              type: Primitive
-                              primitiveType: Boolean
-                            }
-                          }
-                        }
-                        rhs {
-                          type: MethodCall
-                          methodCall {
-                            receiver {
-                              type: VarRef
-                              varRef {
-                                name: "CaseClass$1"
-                              }
-                            }
-                            signature {
-                              name: "canEqual"
-                              owner {
+                              type: Named
+                              namedType {
                                 name: "CaseClass"
                               }
-                              paramType {
-                                type: Named
-                                namedType {
-                                  pkg: "java.lang"
-                                  name: "Object"
+                            }
+                            name: "CaseClass$1"
+                            initializer {
+                              type: Cast
+                              cast {
+                                expr {
+                                  type: VarRef
+                                  varRef {
+                                    name: "x$1"
+                                  }
+                                }
+                                tpe {
+                                  type: Named
+                                  namedType {
+                                    name: "CaseClass"
+                                  }
                                 }
                               }
-                              returnType {
-                                type: Primitive
-                                primitiveType: Boolean
-                              }
-                            }
-                            argument {
-                              type: ThisRef
                             }
                           }
                         }
-                        tpe {
-                          type: Primitive
-                          primitiveType: Boolean
+                        statement {
+                          type: Expr
+                          expr {
+                            type: Assignment
+                            assignment {
+                              lhs {
+                                type: VarRef
+                                varRef {
+                                  name: "$4$"
+                                }
+                              }
+                              rhs {
+                                type: Binary
+                                binary {
+                                  op: And
+                                  lhs {
+                                    type: Binary
+                                    binary {
+                                      op: Equal
+                                      lhs {
+                                        type: MethodCall
+                                        methodCall {
+                                          receiver {
+                                            type: ThisRef
+                                          }
+                                          signature {
+                                            name: "x"
+                                            owner {
+                                              name: "CaseClass"
+                                            }
+                                            returnType {
+                                              type: Primitive
+                                              primitiveType: Int
+                                            }
+                                          }
+                                        }
+                                      }
+                                      rhs {
+                                        type: MethodCall
+                                        methodCall {
+                                          receiver {
+                                            type: VarRef
+                                            varRef {
+                                              name: "CaseClass$1"
+                                            }
+                                          }
+                                          signature {
+                                            name: "x"
+                                            owner {
+                                              name: "CaseClass"
+                                            }
+                                            returnType {
+                                              type: Primitive
+                                              primitiveType: Int
+                                            }
+                                          }
+                                        }
+                                      }
+                                      tpe {
+                                        type: Primitive
+                                        primitiveType: Boolean
+                                      }
+                                    }
+                                  }
+                                  rhs {
+                                    type: MethodCall
+                                    methodCall {
+                                      receiver {
+                                        type: VarRef
+                                        varRef {
+                                          name: "CaseClass$1"
+                                        }
+                                      }
+                                      signature {
+                                        name: "canEqual"
+                                        owner {
+                                          name: "CaseClass"
+                                        }
+                                        paramType {
+                                          type: Named
+                                          namedType {
+                                            pkg: "java.lang"
+                                            name: "Object"
+                                          }
+                                        }
+                                        returnType {
+                                          type: Primitive
+                                          primitiveType: Boolean
+                                        }
+                                      }
+                                      argument {
+                                        type: ThisRef
+                                      }
+                                    }
+                                  }
+                                  tpe {
+                                    type: Primitive
+                                    primitiveType: Boolean
+                                  }
+                                }
+                              }
+                            }
+                          }
                         }
                       }
                     }
-                    tpe {
-                      type: Primitive
-                      primitiveType: Boolean
+                    elsee {
+                      type: Block
+                      block {
+                        statement {
+                          type: Expr
+                          expr {
+                            type: Assignment
+                            assignment {
+                              lhs {
+                                type: VarRef
+                                varRef {
+                                  name: "$4$"
+                                }
+                              }
+                              rhs {
+                                type: Literal
+                                literal {
+                                  type: Boolean
+                                  boolValue: false
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
-                tpe {
-                  type: Primitive
-                  primitiveType: Boolean
+                statement {
+                  type: Expr
+                  expr {
+                    type: Assignment
+                    assignment {
+                      lhs {
+                        type: VarRef
+                        varRef {
+                          name: "$3$"
+                        }
+                      }
+                      rhs {
+                        type: VarRef
+                        varRef {
+                          name: "$4$"
+                        }
+                      }
+                    }
+                  }
                 }
+              }
+            }
+          }
+        }
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: VarRef
+              varRef {
+                name: "$3$"
               }
             }
           }

--- a/test/files/jribble/lazyOperators.check/Test.jribbletxt
+++ b/test/files/jribble/lazyOperators.check/Test.jribbletxt
@@ -1,0 +1,846 @@
+name {
+  name: "Test"
+}
+modifiers {
+  isPublic: true
+}
+ext {
+  pkg: "java.lang"
+  name: "Object"
+}
+implements {
+  pkg: "scala"
+  name: "ScalaObject"
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "testCaseOr"
+    returnType {
+      type: Primitive
+      primitiveType: Boolean
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: VarDef
+          varDef {
+            tpe {
+              type: Primitive
+              primitiveType: Boolean
+            }
+            name: "$1$"
+          }
+        }
+        statement {
+          type: If
+          ifStat {
+            condition {
+              type: Literal
+              literal {
+                type: Boolean
+                boolValue: true
+              }
+            }
+            then {
+              type: Block
+              block {
+                statement {
+                  type: Expr
+                  expr {
+                    type: Assignment
+                    assignment {
+                      lhs {
+                        type: VarRef
+                        varRef {
+                          name: "$1$"
+                        }
+                      }
+                      rhs {
+                        type: Literal
+                        literal {
+                          type: Boolean
+                          boolValue: true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            elsee {
+              type: Block
+              block {
+                statement {
+                  type: Expr
+                  expr {
+                    type: MethodCall
+                    methodCall {
+                      receiver {
+                        type: ThisRef
+                      }
+                      signature {
+                        name: "shouldNotCall"
+                        owner {
+                          name: "Test"
+                        }
+                        returnType {
+                          type: Void
+                        }
+                      }
+                    }
+                  }
+                }
+                statement {
+                  type: Expr
+                  expr {
+                    type: Assignment
+                    assignment {
+                      lhs {
+                        type: VarRef
+                        varRef {
+                          name: "$1$"
+                        }
+                      }
+                      rhs {
+                        type: Literal
+                        literal {
+                          type: Boolean
+                          boolValue: true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: VarRef
+              varRef {
+                name: "$1$"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "testCaseAnd"
+    returnType {
+      type: Primitive
+      primitiveType: Boolean
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: VarDef
+          varDef {
+            tpe {
+              type: Primitive
+              primitiveType: Boolean
+            }
+            name: "$2$"
+          }
+        }
+        statement {
+          type: If
+          ifStat {
+            condition {
+              type: Literal
+              literal {
+                type: Boolean
+                boolValue: false
+              }
+            }
+            then {
+              type: Block
+              block {
+                statement {
+                  type: Expr
+                  expr {
+                    type: MethodCall
+                    methodCall {
+                      receiver {
+                        type: ThisRef
+                      }
+                      signature {
+                        name: "shouldNotCall"
+                        owner {
+                          name: "Test"
+                        }
+                        returnType {
+                          type: Void
+                        }
+                      }
+                    }
+                  }
+                }
+                statement {
+                  type: Expr
+                  expr {
+                    type: Assignment
+                    assignment {
+                      lhs {
+                        type: VarRef
+                        varRef {
+                          name: "$2$"
+                        }
+                      }
+                      rhs {
+                        type: Literal
+                        literal {
+                          type: Boolean
+                          boolValue: true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            elsee {
+              type: Block
+              block {
+                statement {
+                  type: Expr
+                  expr {
+                    type: Assignment
+                    assignment {
+                      lhs {
+                        type: VarRef
+                        varRef {
+                          name: "$2$"
+                        }
+                      }
+                      rhs {
+                        type: Literal
+                        literal {
+                          type: Boolean
+                          boolValue: false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: VarRef
+              varRef {
+                name: "$2$"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "testCaseOrComplex"
+    returnType {
+      type: Primitive
+      primitiveType: Boolean
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Expr
+          expr {
+            type: MethodCall
+            methodCall {
+              receiver {
+                type: ThisRef
+              }
+              signature {
+                name: "callA"
+                owner {
+                  name: "Test"
+                }
+                returnType {
+                  type: Void
+                }
+              }
+            }
+          }
+        }
+        statement {
+          type: VarDef
+          varDef {
+            tpe {
+              type: Primitive
+              primitiveType: Boolean
+            }
+            name: "$3$"
+          }
+        }
+        statement {
+          type: If
+          ifStat {
+            condition {
+              type: Literal
+              literal {
+                type: Boolean
+                boolValue: true
+              }
+            }
+            then {
+              type: Block
+              block {
+                statement {
+                  type: Expr
+                  expr {
+                    type: Assignment
+                    assignment {
+                      lhs {
+                        type: VarRef
+                        varRef {
+                          name: "$3$"
+                        }
+                      }
+                      rhs {
+                        type: Literal
+                        literal {
+                          type: Boolean
+                          boolValue: true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            elsee {
+              type: Block
+              block {
+                statement {
+                  type: Expr
+                  expr {
+                    type: MethodCall
+                    methodCall {
+                      receiver {
+                        type: ThisRef
+                      }
+                      signature {
+                        name: "callB"
+                        owner {
+                          name: "Test"
+                        }
+                        returnType {
+                          type: Void
+                        }
+                      }
+                    }
+                  }
+                }
+                statement {
+                  type: Expr
+                  expr {
+                    type: Assignment
+                    assignment {
+                      lhs {
+                        type: VarRef
+                        varRef {
+                          name: "$3$"
+                        }
+                      }
+                      rhs {
+                        type: Literal
+                        literal {
+                          type: Boolean
+                          boolValue: false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        statement {
+          type: VarDef
+          varDef {
+            tpe {
+              type: Primitive
+              primitiveType: Boolean
+            }
+            name: "$4$"
+          }
+        }
+        statement {
+          type: If
+          ifStat {
+            condition {
+              type: VarRef
+              varRef {
+                name: "$3$"
+              }
+            }
+            then {
+              type: Block
+              block {
+                statement {
+                  type: Expr
+                  expr {
+                    type: Assignment
+                    assignment {
+                      lhs {
+                        type: VarRef
+                        varRef {
+                          name: "$4$"
+                        }
+                      }
+                      rhs {
+                        type: Literal
+                        literal {
+                          type: Boolean
+                          boolValue: true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            elsee {
+              type: Block
+              block {
+                statement {
+                  type: Expr
+                  expr {
+                    type: MethodCall
+                    methodCall {
+                      receiver {
+                        type: ThisRef
+                      }
+                      signature {
+                        name: "callC"
+                        owner {
+                          name: "Test"
+                        }
+                        returnType {
+                          type: Void
+                        }
+                      }
+                    }
+                  }
+                }
+                statement {
+                  type: Expr
+                  expr {
+                    type: Assignment
+                    assignment {
+                      lhs {
+                        type: VarRef
+                        varRef {
+                          name: "$4$"
+                        }
+                      }
+                      rhs {
+                        type: Literal
+                        literal {
+                          type: Boolean
+                          boolValue: false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: VarRef
+              varRef {
+                name: "$4$"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "testCaseAndComplex"
+    returnType {
+      type: Primitive
+      primitiveType: Boolean
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Expr
+          expr {
+            type: MethodCall
+            methodCall {
+              receiver {
+                type: ThisRef
+              }
+              signature {
+                name: "callA"
+                owner {
+                  name: "Test"
+                }
+                returnType {
+                  type: Void
+                }
+              }
+            }
+          }
+        }
+        statement {
+          type: VarDef
+          varDef {
+            tpe {
+              type: Primitive
+              primitiveType: Boolean
+            }
+            name: "$5$"
+          }
+        }
+        statement {
+          type: If
+          ifStat {
+            condition {
+              type: Literal
+              literal {
+                type: Boolean
+                boolValue: false
+              }
+            }
+            then {
+              type: Block
+              block {
+                statement {
+                  type: Expr
+                  expr {
+                    type: MethodCall
+                    methodCall {
+                      receiver {
+                        type: ThisRef
+                      }
+                      signature {
+                        name: "callB"
+                        owner {
+                          name: "Test"
+                        }
+                        returnType {
+                          type: Void
+                        }
+                      }
+                    }
+                  }
+                }
+                statement {
+                  type: Expr
+                  expr {
+                    type: Assignment
+                    assignment {
+                      lhs {
+                        type: VarRef
+                        varRef {
+                          name: "$5$"
+                        }
+                      }
+                      rhs {
+                        type: Literal
+                        literal {
+                          type: Boolean
+                          boolValue: false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            elsee {
+              type: Block
+              block {
+                statement {
+                  type: Expr
+                  expr {
+                    type: Assignment
+                    assignment {
+                      lhs {
+                        type: VarRef
+                        varRef {
+                          name: "$5$"
+                        }
+                      }
+                      rhs {
+                        type: Literal
+                        literal {
+                          type: Boolean
+                          boolValue: false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        statement {
+          type: VarDef
+          varDef {
+            tpe {
+              type: Primitive
+              primitiveType: Boolean
+            }
+            name: "$6$"
+          }
+        }
+        statement {
+          type: If
+          ifStat {
+            condition {
+              type: VarRef
+              varRef {
+                name: "$5$"
+              }
+            }
+            then {
+              type: Block
+              block {
+                statement {
+                  type: Expr
+                  expr {
+                    type: MethodCall
+                    methodCall {
+                      receiver {
+                        type: ThisRef
+                      }
+                      signature {
+                        name: "callC"
+                        owner {
+                          name: "Test"
+                        }
+                        returnType {
+                          type: Void
+                        }
+                      }
+                    }
+                  }
+                }
+                statement {
+                  type: Expr
+                  expr {
+                    type: Assignment
+                    assignment {
+                      lhs {
+                        type: VarRef
+                        varRef {
+                          name: "$6$"
+                        }
+                      }
+                      rhs {
+                        type: Literal
+                        literal {
+                          type: Boolean
+                          boolValue: false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            elsee {
+              type: Block
+              block {
+                statement {
+                  type: Expr
+                  expr {
+                    type: Assignment
+                    assignment {
+                      lhs {
+                        type: VarRef
+                        varRef {
+                          name: "$6$"
+                        }
+                      }
+                      rhs {
+                        type: Literal
+                        literal {
+                          type: Boolean
+                          boolValue: false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: VarRef
+              varRef {
+                name: "$6$"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "shouldNotCall"
+    returnType {
+      type: Void
+    }
+    body {
+      type: Block
+      block {
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "callA"
+    returnType {
+      type: Void
+    }
+    body {
+      type: Block
+      block {
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "callB"
+    returnType {
+      type: Void
+    }
+    body {
+      type: Block
+      block {
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "callC"
+    returnType {
+      type: Void
+    }
+    body {
+      type: Block
+      block {
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    isConstructor: true
+    name: "new"
+    returnType {
+      type: Named
+      namedType {
+        name: "Test"
+      }
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Expr
+          expr {
+            type: MethodCall
+            methodCall {
+              receiver {
+                type: ThisRef
+              }
+              signature {
+                name: "new"
+                owner {
+                  pkg: "java.lang"
+                  name: "Object"
+                }
+                returnType {
+                  type: Named
+                  namedType {
+                    pkg: "java.lang"
+                    name: "Object"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/files/jribble/lazyOperators.scala
+++ b/test/files/jribble/lazyOperators.scala
@@ -1,0 +1,13 @@
+class Test {
+
+  def testCaseOr = { true || { shouldNotCall(); true } }
+  def testCaseAnd = { false && { shouldNotCall(); true } }
+  def testCaseOrComplex = { { callA(); true } || { callB(); false } || { callC(); false} }
+  def testCaseAndComplex = { { callA(); false } && { callB(); false } && { callC(); false} }
+
+  def shouldNotCall() = {}
+  def callA() = {}
+  def callB() = {}
+  def callC() = {}
+
+}


### PR DESCRIPTION
The latest merge from scala master has exposed a bug in the jribble transformation phase. 

scala.collection.immutable.Range now has a construct similar to {a || b} where b() contained side effects and the common case was for a to be true.

I've tracked down the issue and attempted to implement a fix with the guidance from Lex and Grzegorz.

I also tried to add a test but couldn't figure out how to get them to happily run.

See this thread for more details:
https://groups.google.com/forum/#!topic/scalagwt/vzL-e1pE-H8
