### PR TITLE
Add Java enums support to jribble. 

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jribble/ProtobufConverter.scala
+++ b/src/compiler/scala/tools/nsc/backend/jribble/ProtobufConverter.scala
@@ -419,6 +419,18 @@ abstract class ProtobufConverter extends AnyRef with JribbleAnalysis {
         classLiteral.setTpe(convert(x))
         proto.setClassLiteral(classLiteral)
 
+      case Literal(constant: Constant)
+      //reference to Java's enum constant
+      if (constant.tag == EnumTag) =>
+        val sym = constant.symbolValue
+        //enum constants are encoded as references to static fields
+        proto.setType(P.Expr.ExprType.FieldRef)
+        val fieldRef = P.FieldRef.newBuilder
+        fieldRef.setEnclosingType(globalName(sym.owner))
+        fieldRef.setName(sym.javaSimpleName.toString)
+        fieldRef.setTpe(convert(sym.tpe.underlying))
+        proto.setFieldRef(fieldRef)
+
       case Literal(constant: Constant) =>
         proto.setType(P.Expr.ExprType.Literal)
         proto.setLiteral(convertLiteral(constant))

--- a/src/partest/scala/tools/partest/nest/FileManager.scala
+++ b/src/partest/scala/tools/partest/nest/FileManager.scala
@@ -36,14 +36,19 @@ trait FileUtil {
 
   /**
    * Compares two directories using compareFiles method.
+   *
+   * It applies `filter` predicate before comparing contents
+   * of `d1` and `d2`.
    */
-  def compareDirectories(d1: Directory, d2: Directory): List[String] = {
+  def compareDirectories(d1: Directory, d2: Directory, filter: Path => Boolean = (_ => true)): List[String] = {
     def explainNoCorresponding(x: Path, in: Path) =
       "'%s' has no corresponding file in '%s'".format(x, in)
     //obtain relative sets of relative paths that can be compared
     //so we can find files with missing corresponding file in another directory
-    val fs1 = d1.deepFiles.map(d1.relativize(_)).toSet
-    val fs2 = d2.deepFiles.map(d2.relativize(_)).toSet
+    val files1 = Path.onlyFiles(d1.walkFilter(filter))
+    val files2 = Path.onlyFiles(d2.walkFilter(filter))
+    val fs1 = files1.map(d1.relativize(_)).toSet
+    val fs2 = files2.map(d2.relativize(_)).toSet
     val noCorresponding1 = (fs2 -- fs1).toList.map(explainNoCorresponding(_, d1))
     val noCorresponding2 = (fs1 -- fs2).toList.map(explainNoCorresponding(_, d2))
     val noCorresponding = noCorresponding1 ++ noCorresponding2

--- a/src/partest/scala/tools/partest/nest/Worker.scala
+++ b/src/partest/scala/tools/partest/nest/Worker.scala
@@ -596,7 +596,8 @@ class Worker(val fileManager: FileManager, params: TestRunParams) extends Actor 
         val dir      = file.getParentFile
         val checkDir = Directory(dir) / Directory(fileBase + ".check")
 
-        fileManager.compareDirectories(checkDir, Directory(outDir)) match {
+        // Rule out .class files. Those are the only ones we want to exclude for now.
+        fileManager.compareDirectories(checkDir, Directory(outDir), _.extension != "class") match {
           case Nil => true
           case xs => {
             diff = xs mkString "\n"

--- a/test/files/jribble/enum.check/Bar.jribbletxt
+++ b/test/files/jribble/enum.check/Bar.jribbletxt
@@ -1,0 +1,166 @@
+name {
+  name: "Bar"
+}
+modifiers {
+  isPublic: true
+}
+ext {
+  pkg: "java.lang"
+  name: "Object"
+}
+implements {
+  pkg: "scala"
+  name: "ScalaObject"
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "m1"
+    paramDef {
+      name: "x"
+      tpe {
+        type: Named
+        namedType {
+          name: "Foo$Foo2"
+        }
+      }
+    }
+    returnType {
+      type: Named
+      namedType {
+        name: "Foo$Foo2"
+      }
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: VarRef
+              varRef {
+                name: "x"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    name: "m2"
+    returnType {
+      type: Named
+      namedType {
+        name: "Foo$Foo2"
+      }
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Return
+          returnStat {
+            expression {
+              type: MethodCall
+              methodCall {
+                receiver {
+                  type: ThisRef
+                }
+                signature {
+                  name: "m1"
+                  owner {
+                    name: "Bar"
+                  }
+                  paramType {
+                    type: Named
+                    namedType {
+                      name: "Foo$Foo2"
+                    }
+                  }
+                  returnType {
+                    type: Named
+                    namedType {
+                      name: "Foo$Foo2"
+                    }
+                  }
+                }
+                argument {
+                  type: FieldRef
+                  fieldRef {
+                    enclosingType {
+                      name: "Foo$Foo2"
+                    }
+                    name: "SomeFoo2"
+                    tpe {
+                      type: Named
+                      namedType {
+                        name: "Foo$Foo2"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+member {
+  type: Method
+  modifiers {
+    isPublic: true
+  }
+  method {
+    isConstructor: true
+    name: "new"
+    returnType {
+      type: Named
+      namedType {
+        name: "Bar"
+      }
+    }
+    body {
+      type: Block
+      block {
+        statement {
+          type: Expr
+          expr {
+            type: MethodCall
+            methodCall {
+              receiver {
+                type: ThisRef
+              }
+              signature {
+                name: "new"
+                owner {
+                  pkg: "java.lang"
+                  name: "Object"
+                }
+                returnType {
+                  type: Named
+                  namedType {
+                    pkg: "java.lang"
+                    name: "Object"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/files/jribble/enum/Bar.scala
+++ b/test/files/jribble/enum/Bar.scala
@@ -1,0 +1,7 @@
+class Bar {
+
+  def m1(x: Foo.Foo2) = x
+
+  def m2 = m1(Foo.Foo2.SomeFoo2)
+
+}

--- a/test/files/jribble/enum/Foo.java
+++ b/test/files/jribble/enum/Foo.java
@@ -1,0 +1,7 @@
+public class Foo {
+
+  public enum Foo2 {
+    SomeFoo2 {}
+  }
+
+}


### PR DESCRIPTION
Add support for referring to Java
enum values from Scala. They are
properly encoded in jribble as
static field references.

Added test-case covering this
functionality.

Fixes scalagwt#1. Yep, the first
issue ever created :-)
